### PR TITLE
#162879289 Add patch downvote and upvote endpoints

### DIFF
--- a/dist/models/questions.js
+++ b/dist/models/questions.js
@@ -64,15 +64,31 @@ var addQuestion = function addQuestion(question) {
 exports.addQuestion = addQuestion;
 
 var increaseVote = function increaseVote(id) {
-  var question = getQuestionId(id);
+  // Check if id exist
+  var question = getQuestionId(id); // Returns if id doesn't exist
+
+  if (!question) {
+    return;
+  } // increase votes by one(1)
+
+
   question.votes += 1;
+  return [question];
 };
 
 exports.increaseVote = increaseVote;
 
 var decreaseVote = function decreaseVote(id) {
-  var question = getQuestionId(id);
-  question.votes -= 1;
+  // Checks if question with id exist
+  var question = getQuestionId(id); // Return if question with id doesn't exist
+
+  if (!question) {
+    return;
+  } // reduce votes by one(1) only when greater than zero
+
+
+  if (question.votes > 0) question.votes -= 1;
+  return [question];
 };
 
 exports.decreaseVote = decreaseVote;

--- a/dist/routes/question.js
+++ b/dist/routes/question.js
@@ -27,8 +27,8 @@ router.post('/', function (req, res) {
       error: 'all indicated field should be filled'
     });
   } else if (!_lodash.default.isString(body.title) || !_lodash.default.isString(body.body) || !_lodash.default.isNumber(body.createdBy) || !_lodash.default.isNumber(body.meetup) || !_lodash.default.isString(body.createdOn)) {
-    return res.status(400).json({
-      status: 400,
+    return res.status(415).json({
+      status: 415,
       error: 'value types are not correct'
     });
   }
@@ -37,6 +37,42 @@ router.post('/', function (req, res) {
     status: 201,
     data: (0, _questions.addQuestion)(body)
   });
+}); // Patch /api/v1/questions/:id/upvote
+
+router.patch('/:id/upvote', function (req, res) {
+  var questionId = parseInt(req.params.id, 10);
+  var patchedQuestion = (0, _questions.increaseVote)(questionId);
+
+  if (patchedQuestion) {
+    console.log(patchedQuestion);
+    res.status(200).json({
+      status: 200,
+      data: patchedQuestion
+    });
+  } else {
+    res.status(400).json({
+      status: 400,
+      error: 'no question with specified id'
+    });
+  }
+}); // Patch /api/v1/questions/:id/downvote
+
+router.patch('/:id/downvote', function (req, res) {
+  var questionId = parseInt(req.params.id, 10);
+  var patchedQuestion = (0, _questions.decreaseVote)(questionId);
+
+  if (patchedQuestion) {
+    console.log(patchedQuestion);
+    res.status(200).json({
+      status: 200,
+      data: patchedQuestion
+    });
+  } else {
+    res.status(400).json({
+      status: 400,
+      error: 'no question with specified id'
+    });
+  }
 });
 var _default = router;
 exports.default = _default;

--- a/dist/test/question.spec.js
+++ b/dist/test/question.spec.js
@@ -15,20 +15,13 @@ describe('Questions Endpoints test', function () {
   it('Test case for get meetups api call', function () {
     // HTTP get request for /api/v1/meetups
     (0, _supertest.default)(_app.default).post('/api/v1/questions').set('accept', 'aplication/json').expect('content/type', /json/).expect(201);
-  }); // it('Test case for get meetups by id api call', () => {
-  //   // HTTP get request for /api/v1/meetups
-  //   request(app)
-  //     .get('/api/v1/meetups/1')
-  //     .set('accept', 'aplication/json')
-  //     .expect('content/type', /json/)
-  //     .expect(200);
-  // });
-  // it('Test case for post meetups api call', () => {
-  //   // HTTP post request for /api/v1/meetups
-  //   request(app)
-  //     .post('/api/vi/meetups')
-  //     .set('accept', 'aplication/json')
-  //     .expect('content/type', /json/)
-  //     .expect(201);
-  // });
+  });
+  it('Test case for patch questions by id api call', function () {
+    // HTTP patch request for /api/v1/questions/:id/upvote
+    (0, _supertest.default)(_app.default).patch('/api/v1/questions/1/upvote').set('accept', 'aplication/json').expect('content/type', /json/).expect(200);
+  });
+  it('Test case for patch questions by id api call', function () {
+    // HTTP patch request for /api/v1/questions/:id/downvote
+    (0, _supertest.default)(_app.default).patch('/api/v1/questions/1/downvote').set('accept', 'aplication/json').expect('content/type', /json/).expect(200);
+  });
 });

--- a/src/models/questions.js
+++ b/src/models/questions.js
@@ -54,15 +54,33 @@ const addQuestion = (question) => {
 };
 
 const increaseVote = (id) => {
+  // Check if id exist
   const question = getQuestionId(id);
 
+  // Returns if id doesn't exist
+  if(!question){
+    return
+  }
+
+  // increase votes by one(1)
   question.votes += 1;
+
+  return [question]
 };
 
 const decreaseVote = (id) => {
+  // Checks if question with id exist
   const question = getQuestionId(id);
 
-  question.votes -= 1;
+  // Return if question with id doesn't exist
+  if(!question){
+    return
+  }
+
+  // reduce votes by one(1) only when greater than zero
+  if (question.votes > 0) question.votes -= 1;
+
+  return [question]
 };
 
 export {

--- a/src/routes/question.js
+++ b/src/routes/question.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import _ from 'lodash';
-import { addQuestion } from '../models/questions';
+import { addQuestion, increaseVote, decreaseVote } from '../models/questions';
 
 const router = express.Router();
 
@@ -17,8 +17,8 @@ router.post('/', (req, res) => {
       error: 'all indicated field should be filled',
     });
   }else if (!_.isString(body.title) || !_.isString(body.body) || !_.isNumber(body.createdBy) || !_.isNumber(body.meetup) || !_.isString(body.createdOn)) {
-    return res.status(400).json({
-      status: 400,
+    return res.status(415).json({
+      status: 415,
       error: 'value types are not correct',
     });
   }
@@ -27,6 +27,44 @@ router.post('/', (req, res) => {
     status: 201,
     data: addQuestion(body),
   });
+});
+
+// Patch /api/v1/questions/:id/upvote
+router.patch('/:id/upvote', (req, res) => {
+  const questionId = parseInt(req.params.id, 10);
+  const patchedQuestion = increaseVote(questionId);
+
+  if(patchedQuestion){
+    console.log(patchedQuestion);
+    res.status(200).json({
+      status: 200,
+      data: patchedQuestion,
+    })
+  }else{
+    res.status(400).json({
+      status: 400,
+      error: 'no question with specified id'
+    });
+  }
+});
+
+// Patch /api/v1/questions/:id/downvote
+router.patch('/:id/downvote', (req, res) => {
+  const questionId = parseInt(req.params.id, 10);
+  const patchedQuestion = decreaseVote(questionId);
+
+  if(patchedQuestion){
+    console.log(patchedQuestion);
+    res.status(200).json({
+      status: 200,
+      data: patchedQuestion,
+    })
+  }else{
+    res.status(400).json({
+      status: 400,
+      error: 'no question with specified id'
+    });
+  }
 });
 
 export default router;

--- a/src/test/question.spec.js
+++ b/src/test/question.spec.js
@@ -15,21 +15,21 @@ describe('Questions Endpoints test', () => {
       .expect(201);
   });
 
-  // it('Test case for get meetups by id api call', () => {
-  //   // HTTP get request for /api/v1/meetups
-  //   request(app)
-  //     .get('/api/v1/meetups/1')
-  //     .set('accept', 'aplication/json')
-  //     .expect('content/type', /json/)
-  //     .expect(200);
-  // });
+  it('Test case for patch questions by id api call', () => {
+    // HTTP patch request for /api/v1/questions/:id/upvote
+    request(app)
+      .patch('/api/v1/questions/1/upvote')
+      .set('accept', 'aplication/json')
+      .expect('content/type', /json/)
+      .expect(200);
+  });
 
-  // it('Test case for post meetups api call', () => {
-  //   // HTTP post request for /api/v1/meetups
-  //   request(app)
-  //     .post('/api/vi/meetups')
-  //     .set('accept', 'aplication/json')
-  //     .expect('content/type', /json/)
-  //     .expect(201);
-  // });
+  it('Test case for patch questions by id api call', () => {
+    // HTTP patch request for /api/v1/questions/:id/downvote
+    request(app)
+      .patch('/api/v1/questions/1/downvote')
+      .set('accept', 'aplication/json')
+      .expect('content/type', /json/)
+      .expect(200);
+  }); 
 });


### PR DESCRIPTION

#### What does this PR do?
Add upvote and downvote endpoints
____
#### Description of Task to be completed?
for users to be able to upvote a question or
downvote a question so their main question of
interest can bubble up the rank this endpoints
would be consumed as appropriate.
____
#### How should this be manually tested?
create a patch request to localhost:3000/api/v1/questions/:1/upvote or downvote and watch the votes increase or decrease as the case may be.