### PR TITLE
#162983664 Add get all upcoming meetup Endpoint

### DIFF
--- a/dist/models/meetups.js
+++ b/dist/models/meetups.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.addMeetupToRsvp = exports.getMeetupId = exports.addMeetup = exports.getMeetups = void 0;
+exports.getUpcomingMeetup = exports.addMeetupToRsvp = exports.getMeetupId = exports.addMeetup = exports.getMeetups = void 0;
 
 var _RSVP = _interopRequireDefault(require("./RSVP"));
 
@@ -66,11 +66,19 @@ var addMeetup = function addMeetup(meetup) {
 
   meetups.push(meetupToDb);
   return [meetupToDb];
-}; // const getUpcomingMeetup = () => {
-// }
-
+};
 
 exports.addMeetup = addMeetup;
+
+var getUpcomingMeetup = function getUpcomingMeetup() {
+  var today = new Date();
+  var upcomingMeetups = meetups.filter(function (m) {
+    return m.happeningOn < today;
+  });
+  return upcomingMeetups;
+};
+
+exports.getUpcomingMeetup = getUpcomingMeetup;
 
 var addMeetupToRsvp = function addMeetupToRsvp(id, body) {
   var meetupToRsvp = {}; // Check if id exist in meetup

--- a/dist/routes/meetup.js
+++ b/dist/routes/meetup.js
@@ -22,9 +22,22 @@ router.get('/', function (req, res) {
     data: (0, _meetups.getMeetups)()
   });
 }); // Get api/v1/meetups/upcoming
-// router.get('/upcoming', (req, res) => {
-// })
-// Get api/v1/meetups/:id
+
+router.get('/upcoming', function (req, res) {
+  var upcommingMeetup = (0, _meetups.getUpcomingMeetup)();
+
+  if (!upcommingMeetup) {
+    return res.status(200).json({
+      status: 200,
+      data: ['There are no upcoming ']
+    });
+  }
+
+  return res.status(200).json({
+    status: 200,
+    data: upcommingMeetup
+  });
+}); // Get api/v1/meetups/:id
 
 router.get('/:id', function (req, res) {
   var meetupId = parseInt(req.params.id, 10);

--- a/dist/test/meetup.spec.js
+++ b/dist/test/meetup.spec.js
@@ -33,6 +33,10 @@ describe('Meetups Endpoints test', function () {
     // HTTP get request for /api/v1/meetups
     (0, _supertest.default)(_app.default).get('/api/v1/meetups').set('accept', 'aplication/json').expect('content/type', /json/).expect(200);
   });
+  it('Test case for get meetups api call', function () {
+    // HTTP get request for /api/v1/meetups
+    (0, _supertest.default)(_app.default).get('/api/v1/meetups.upcoming').set('accept', 'aplication/json').expect('content/type', /json/).expect(200);
+  });
   it('Test case for get meetups by id api call', function () {
     // HTTP get request for /api/v1/meetups/:<meetupID>
     (0, _supertest.default)(_app.default).get('/api/v1/meetups/1').set('accept', 'aplication/json').expect('content/type', /json/).expect(200);

--- a/src/models/meetups.js
+++ b/src/models/meetups.js
@@ -48,9 +48,13 @@ const addMeetup = (meetup) => {
   return [meetupToDb];
 };
 
-// const getUpcomingMeetup = () => {
+const getUpcomingMeetup = () => {
+  const today = new Date();
 
-// }
+  const upcomingMeetups = meetups.filter(m => m.happeningOn < today);
+
+  return upcomingMeetups;
+};
 
 const addMeetupToRsvp = (id, body) => {
   const meetupToRsvp = {};
@@ -80,5 +84,5 @@ const addMeetupToRsvp = (id, body) => {
 };
 
 export {
-  getMeetups, addMeetup, getMeetupId, addMeetupToRsvp,
+  getMeetups, addMeetup, getMeetupId, addMeetupToRsvp, getUpcomingMeetup,
 };

--- a/src/routes/meetup.js
+++ b/src/routes/meetup.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import _ from 'lodash';
 import {
-  getMeetups, addMeetup, getMeetupId, addMeetupToRsvp,
+  getMeetups, addMeetup, getMeetupId, addMeetupToRsvp, getUpcomingMeetup,
 } from '../models/meetups';
 
 const router = express.Router();
@@ -15,9 +15,21 @@ router.get('/', (req, res) => {
 });
 
 // Get api/v1/meetups/upcoming
-// router.get('/upcoming', (req, res) => {
+router.get('/upcoming', (req, res) => {
+  const upcommingMeetup = getUpcomingMeetup();
 
-// })
+  if (!upcommingMeetup) {
+    return res.status(200).json({
+      status: 200,
+      data: ['There are no upcoming '],
+    });
+  }
+
+  return res.status(200).json({
+    status: 200,
+    data: upcommingMeetup,
+  });
+});
 
 // Get api/v1/meetups/:id
 router.get('/:id', (req, res) => {

--- a/src/test/meetup.spec.js
+++ b/src/test/meetup.spec.js
@@ -34,6 +34,15 @@ describe('Meetups Endpoints test', () => {
       .expect(200);
   });
 
+  it('Test case for get meetups api call', () => {
+    // HTTP get request for /api/v1/meetups
+    request(app)
+      .get('/api/v1/meetups.upcoming')
+      .set('accept', 'aplication/json')
+      .expect('content/type', /json/)
+      .expect(200);
+  });
+
   it('Test case for get meetups by id api call', () => {
     // HTTP get request for /api/v1/meetups/:<meetupID>
     request(app)


### PR DESCRIPTION
#### What does this PR do?
It adds get all endpoint: api/v1/meetups/upcoming
#### Description of Task to be completed?
This endpoint would be consumed to spool for all meetup that has not yet occurred.
#### How should this be manually tested?
create a get request to endpoint: stated above, and its results happeningOn value should not have occurred yet.